### PR TITLE
Update pwm_set_value with inputs and global enum channel

### DIFF
--- a/examples/raspberry-pi.rs
+++ b/examples/raspberry-pi.rs
@@ -1,4 +1,4 @@
-use navigator_rs::{Navigator, SensorData};
+use navigator_rs::{pwm_Channel, Navigator, SensorData};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -26,7 +26,7 @@ fn main() {
     println!("mag values: X={},Y={},Z={}", read.x, read.y, read.z);
     println!("Reading all sensors with read_all");
     loop {
-        nav.set_pwm_value();
+        nav.set_pwm_channel_value(pwm_Channel::All, 0);
         let sensor_data: SensorData = nav.read_all();
         println!(
             "ADC values: {}, {}, {}, {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,26 @@ impl Navigator {
         self.pwm.set_channel_off(channel, value).unwrap();
     }
 
+    pub fn set_pwm_channels_value<const N: usize>(
+        &mut self,
+        channels: &[pwm_Channel; N],
+        value: u16,
+    ) {
+        for &channel in channels.iter().take(N) {
+            self.set_pwm_channel_value(channel, value)
+        }
+    }
+
+    pub fn set_pwm_channels_values<const N: usize>(
+        &mut self,
+        channels: &[pwm_Channel; N],
+        values: &[u16; N],
+    ) {
+        for i in 0..N {
+            self.set_pwm_channel_value(channels[i], values[i])
+        }
+    }
+
     pub fn set_pwm_freq(&mut self) {
         todo!()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@ use linux_embedded_hal::sysfs_gpio::Direction;
 use linux_embedded_hal::I2cdev;
 use linux_embedded_hal::{Delay, Pin, Spidev};
 use nb::block;
-use pwm_pca9685::{Address as pwm_Address, Channel as pwm_Channel, Pca9685};
+use pwm_pca9685::{Address as pwm_Address, Pca9685};
+
+pub use pwm_pca9685::Channel as pwm_Channel;
 
 pub struct AxisData {
     pub x: f32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,10 +184,8 @@ impl Navigator {
             .expect("Error : Error on magnetometer during self-test")
     }
 
-    pub fn set_pwm_value(&mut self) {
-        let channel = pwm_Channel::C0; //todo import enums
-        let value = 2047; //todo a fomula that validades from 0 to 100.00% and convert to 4092
-        self.pwm.set_channel_on(channel, 0).unwrap(); //Channel::C0
+    pub fn set_pwm_channel_value(&mut self, channel: pwm_Channel, value: u16) {
+        self.pwm.set_channel_on(channel, 0).unwrap();
         self.pwm.set_channel_off(channel, value).unwrap();
     }
 


### PR DESCRIPTION
Add pwm_Channel global enum for user,
Fix the pwm_set_value, now with inputs (channel and value)
Add pwm_set_value_mult, which set values for a array, &[ch1,ch2,ch3]
Update example and add new one with random values.