### PR TITLE
pwm: Add oe_pin to pwm methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,14 @@ impl Navigator {
         cs_1.set_direction(Direction::High)
             .expect("Error: Setting CS2 pin as output");
 
+        //Define pwm OE_Pin - PWM initialize disabled
+        let oe_pin = Pin::new(26);
+        oe_pin.export().expect("Error: Error during oe_pin export");
+        Delay {}.delay_ms(30_u16);
+        oe_pin
+            .set_direction(Direction::High)
+            .expect("Error: Setting oe_pin pin as output");
+
         let imu = imu_Builder::new_spi(spi, cs_2);
 
         let led = Led::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,6 @@ impl Navigator {
         self.pwm.reset_internal_driver_state();
         self.pwm.use_external_clock().unwrap();
         self.pwm.set_prescale(100).unwrap();
-        self.pwm.enable().unwrap();
 
         self.bmp.zero().unwrap();
 
@@ -220,6 +219,16 @@ impl Navigator {
         self.mag
             .self_test()
             .expect("Error : Error on magnetometer during self-test")
+    }
+
+    pub fn pwm_enable(&mut self) {
+        self.pwm.enable().unwrap();
+        self.pwm.oe_pin.set_direction(Direction::Low).unwrap();
+    }
+
+    pub fn pwm_disable(&mut self) {
+        self.pwm.disable().unwrap();
+        self.pwm.oe_pin.set_direction(Direction::High).unwrap();
     }
 
     pub fn set_pwm_channel_value(&mut self, channel: pwm_Channel, value: u16) {


### PR DESCRIPTION
From:
[Ardupilit-PCA9685](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp)
and
![image](https://github.com/bluerobotics/navigator-rs/assets/80598030/076c2361-02b0-4510-8724-a1a308fe52da)

Oe_pin should be defined to enable pwm outputs.