### PR TITLE
Create a channel stantard

### DIFF
--- a/examples/raspberry-pi.rs
+++ b/examples/raspberry-pi.rs
@@ -1,4 +1,4 @@
-use navigator_rs::{pwm_Channel, Navigator, SensorData};
+use navigator_rs::{Navigator, PwmChannel};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -10,7 +10,7 @@ fn main() {
     nav.init();
 
     loop {
-        nav.set_pwm_channel_value(pwm_Channel::All, 0);
+        nav.set_pwm_channel_value(PwmChannel::All, 0);
         println!("{:#?}", nav.fmt_debug());
         sleep(Duration::from_millis(1000));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,7 @@ impl Navigator {
     /// use navigator_rs::{Navigator, PwmChannel};
     ///
     /// let mut nav = Navigator::new();
+    ///
     /// nav.init();
     /// nav.pwm_enable();
     ///
@@ -413,6 +414,7 @@ impl Navigator {
     /// use navigator_rs::{Navigator, PwmChannel};
     ///
     /// let mut nav = Navigator::new();
+    ///
     /// nav.init();
     /// nav.pwm_enable();
     ///
@@ -444,8 +446,10 @@ impl Navigator {
     /// use std::time::Duration;
     ///
     /// let mut nav = Navigator::new();
+    ///
     /// nav.init();
     /// nav.pwm_enable();
+    ///
     /// let mut i: f32 = 10.0;
     ///
     /// loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ impl Navigator {
             .expect("Error: Failed to build BMP280 device");
         bmp.zero().unwrap();
 
-        let mut spi = Spidev::open("/dev/spidev1.0").expect("Error: Failled during setting up SPI");
+        let mut spi = Spidev::open("/dev/spidev1.0").expect("Error: Failed during setting up SPI");
         let options = SpidevOptions::new()
             .bits_per_word(8)
             .max_speed_hz(10_000_000)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ impl Navigator {
     /// # Examples
     ///
     /// ```no_run
-    /// use navigator_rs::{pwm_Channel, Navigator};
+    /// use navigator_rs::{Navigator, PwmChannel};
     ///
     /// let mut nav = Navigator::new();
     /// nav.init();
@@ -326,6 +326,25 @@ impl Navigator {
         self.pwm.set_channel_off(channel.into(), value).unwrap();
     }
 
+    /// Like [`set_pwm_channel_value`](struct.Navigator.html#method.set_pwm_channel_value). This function
+    /// sets the Duty Cycle for a list of multiple channels.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use navigator_rs::{Navigator, PwmChannel};
+    ///
+    /// let mut nav = Navigator::new();
+    ///
+    /// nav.init();
+    /// nav.pwm_enable();
+    /// nav.set_pwm_freq_prescale(99); // sets the pwm frequency to 60 Hz
+    ///
+    /// let channels: [PwmChannel; 3] = [PwmChannel::Ch0, PwmChannel::Ch1, PwmChannel::Ch2];
+    /// let values: [u16; 3] = [200, 1000, 300];
+    ///
+    /// nav.set_pwm_channels_value(&channels, 2048); // sets the duty cycle according to the list.
+    /// ```
     pub fn set_pwm_channels_value<const N: usize>(
         &mut self,
         channels: &[PwmChannel; N],
@@ -336,6 +355,25 @@ impl Navigator {
         }
     }
 
+    /// Like [`set_pwm_channel_value`](struct.Navigator.html#method.set_pwm_channel_value). This function
+    /// sets the Duty Cycle for a list of multiple channels with multiple values.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use navigator_rs::{Navigator, PwmChannel};
+    ///
+    /// let mut nav = Navigator::new();
+    ///
+    /// nav.init();
+    /// nav.pwm_enable();
+    /// nav.set_pwm_freq_prescale(99); // sets the pwm frequency to 60 Hz
+    ///
+    /// let channels: [PwmChannel; 3] = [PwmChannel::Ch0, PwmChannel::Ch1, PwmChannel::Ch2];
+    /// let values: [u16; 3] = [200, 1000, 300];
+    ///
+    /// nav.set_pwm_channels_values(&channels, &values); // sets the duty cycle according to the lists.
+    /// ```
     pub fn set_pwm_channels_values<const N: usize>(
         &mut self,
         channels: &[PwmChannel; N],
@@ -372,7 +410,7 @@ impl Navigator {
     /// # Examples
     ///
     /// ```no_run
-    /// use navigator_rs::{pwm_Channel, Navigator};
+    /// use navigator_rs::{Navigator, PwmChannel};
     ///
     /// let mut nav = Navigator::new();
     /// nav.init();
@@ -401,7 +439,7 @@ impl Navigator {
     /// # Examples
     ///
     /// ```no_run
-    /// use navigator_rs::{pwm_Channel, Navigator, SensorData};
+    /// use navigator_rs::{Navigator, PwmChannel};
     /// use std::thread::sleep;
     /// use std::time::Duration;
     ///


### PR DESCRIPTION
- [x] Needs [PR-13](https://github.com/bluerobotics/navigator-rs/pull/13)
- [x] Rebase

Like we did on navigator-lib, channels should be called with Ch*,

As here:
```
PwmChannel::Ch1
AdcChannel::Ch1
```
*As pointed on Raom meeting, DiffChannels wasn't added to the navigator AdcChannel

Also add more documentation files for set_pwm_channel_value related functions.

