### PR TITLE
Adc upgrades

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub struct AxisData {
 
 #[derive(Debug)]
 pub struct ADCData {
-    pub channel: [i16; 4],
+    pub channel: [f32; 4],
 }
 
 #[derive(Debug)]
@@ -525,8 +525,27 @@ impl Navigator {
         }
     }
 
-    pub fn read_adc(&mut self, channel: AdcChannel) -> i16 {
-        block!(self.adc.read(channel.into())).unwrap()
+    /// Reads the ADC based on ADS1115 of [`Navigator`].
+    ///
+    /// Measurements in \[V\]
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use navigator_rs::{AdcChannel, Navigator};
+    /// use std::thread::sleep;
+    /// use std::time::Duration;
+    ///
+    /// let mut nav = Navigator::new();
+    /// nav.init();
+    ///
+    /// loop {
+    ///     println!("ADC channel 1 value: {} [V]", nav.read_adc(AdcChannel::Ch1));
+    ///     sleep(Duration::from_millis(1000));
+    /// }
+    pub fn read_adc(&mut self, channel: AdcChannel) -> f32 {
+        let conversion_volts: f32 = 0.000_125; // According to data-sheet, LSB = 125 μV for ±4.096 scale register, navigator's default
+        block!(self.adc.read(channel.into())).unwrap() as f32 * conversion_volts
     }
 
     pub fn read_accel(&mut self) -> AxisData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,9 @@ impl Navigator {
         self.imu.set_gyro_range(GyroRange::Range_250dps).unwrap();
 
         self.adc.reset_internal_driver_state();
+        self.adc
+            .set_full_scale_range(ads1x1x::FullScaleRange::Within4_096V)
+            .unwrap();
 
         self.pwm.reset_internal_driver_state();
         self.pwm.use_external_clock().unwrap();


### PR DESCRIPTION
Needs rebase over:
- [x] https://github.com/bluerobotics/navigator-rs/pull/14

Change adc scale according the schematics, using:
 ±4.096 V with LSB - 125 μV
 [FullScale Register](https://www.ti.com/lit/ds/symlink/ads1115.pdf#page=17)

Change the output of adc to a converted value,
