### PR TITLE
Remove reduntant functions set_pwm_all_on & off

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,15 +589,6 @@ impl Navigator {
 
         self.set_pwm_freq_prescale(prescale_clamped_value);
     }
-
-    pub fn set_pwm_off(&mut self) {
-        todo!()
-    }
-
-    pub fn set_pwm_on(&mut self) {
-        todo!()
-    }
-
     /// Gets the navigator LED output state based on it's color. The true state means the LED is on.
     ///
     /// # Arguments


### PR DESCRIPTION
We can just remove this functions, or keep then as follows.
it's just an use case of `set_pwm_channel_value` with `PwmChannels::All`