### PR TITLE
src: lib: Change the sensor readings axes to navigator's standard

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -722,7 +722,12 @@ impl Navigator {
     /// ```
     pub fn read_mag(&mut self) -> AxisData {
         let (x, y, z) = self.mag.read().unwrap();
-        AxisData { x, y, z }
+        // Change the axes to navigator's standard. Right-handed, Z-axis down (aeronautical frame, NED).
+        AxisData {
+            x: y,
+            y: x * -1.0,
+            z,
+        }
     }
 
     /// Reads the temperature using BMP280 of [`Navigator`].
@@ -878,10 +883,13 @@ impl Navigator {
     /// ```
     pub fn read_accel(&mut self) -> AxisData {
         let reading: [f32; 3] = self.imu.get_scaled_accel().unwrap();
+        // Change the axes to navigator's standard. Right-handed, Z-axis down (aeronautical frame, NED).
+        // Obs.: ICM20602 sensor is measuring with inverted directions, not following data-sheet.
+        //       Thus, with IC's placement only Z needs to be inverted.
         AxisData {
             x: reading[0],
             y: reading[1],
-            z: reading[2],
+            z: reading[2] * -1.0,
         }
     }
 
@@ -907,9 +915,10 @@ impl Navigator {
     /// ```
     pub fn read_gyro(&mut self) -> AxisData {
         let reading: [f32; 3] = self.imu.get_scaled_gyro().unwrap();
+        // Change the axes to navigator's standard. Right-handed, Z-axis down (aeronautical frame, NED).
         AxisData {
-            x: reading[0],
-            y: reading[1],
+            x: reading[0] * -1.0,
+            y: reading[1] * -1.0,
             z: reading[2],
         }
     }


### PR DESCRIPTION
The sensors readings now follows the aeronautical frame system, right-handed, Z-axis down.

https://www.mathworks.com/help/aeroblks/about-aerospace-coordinate-systems.html
![image](https://github.com/bluerobotics/navigator-rs/assets/80598030/c5133504-e965-4773-8b2a-1d85c40b8e3b)


![image](https://github.com/bluerobotics/navigator-rs/assets/80598030/46534242-0081-41d5-a37d-116c1c5fccac)
![image](https://github.com/bluerobotics/navigator-rs/assets/80598030/65ae941b-7a82-4e39-828b-d7f47408e314)


Corrects the open milestone issue:
- [ ] https://github.com/bluerobotics/navigator-rs/issues/25