### PR TITLE
Add automatic deploy & version upgrade

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -40,3 +40,29 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout to repository
+        uses: actions/checkout@v2
+      - name: Setup Rust toolchain 
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+      - name: Install cargo-bump
+        run: cargo install cargo-bump --force
+      - name: Modify version with tag
+        run: cargo bump ${{ github.ref_name }}
+      - name: Automatic commit for crate version upgrade 
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: master
+          commit_message: "Cargo: Update the crate version to ${{ github.ref_name }}"
+      - name: Publish to crates.io
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This new deploy action able our repo to automatically deploy on crates.io.
It also upgrade the current version of the crate and stores it as a commit.

It's triggered by releases with a tag name as: "x.x.x"

This PR closes the last milestone issue for first release.
- [ ] https://github.com/bluerobotics/navigator-rs/issues/24