### PR TITLE
Fix pwm enable/disable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,6 +378,7 @@ impl Navigator {
         self.pwm.reset_internal_driver_state();
         self.pwm.use_external_clock().unwrap();
         self.pwm.set_prescale(100).unwrap();
+        self.pwm.enable().unwrap();
 
         self.bmp.zero().unwrap();
 
@@ -404,10 +405,8 @@ impl Navigator {
     /// Please check [`set_pwm_channel_value`](struct.Navigator.html#method.set_pwm_channel_value).
     pub fn pwm_enable(&mut self, state: bool) {
         if state {
-            self.pwm.enable().unwrap();
             self.pwm.oe_pin.set_direction(Direction::Low).unwrap();
         } else {
-            self.pwm.disable().unwrap();
             self.pwm.oe_pin.set_direction(Direction::High).unwrap();
         }
     }


### PR DESCRIPTION
The current pca9685 library is using enable()/disable() to change SLEEP bit,

And current navigator.pwm_enable() is setting both software (pca9686 sleep bit) and HW (OE pin) to enable/disable.

This create an undisered behavior, if user disable and re-enable he needs to change at least some channel again.

With this PR enable/disable just work directly as expected. 