### PR TITLE
src: lib: adc: Change to use max sample rate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,9 @@ impl Navigator {
         self.adc
             .set_full_scale_range(ads1x1x::FullScaleRange::Within4_096V)
             .unwrap();
+        self.adc
+            .set_data_rate(ads1x1x::DataRate16Bit::Sps860)
+            .unwrap();
 
         self.pwm.reset_internal_driver_state();
         self.pwm.use_external_clock().unwrap();


### PR DESCRIPTION
Improoved the reading time of all 4 channels to 12ms instead previous 40ms.

- https://github.com/bluerobotics/navigator-rs/issues/54

```
read_adc                time:   [3.0672 ms 3.0759 ms 3.0840 ms]
                        change: [-69.244% -69.143% -69.034%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 23 outliers among 100 measurements (23.00%)
  17 (17.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe

read_adc_all            time:   [12.350 ms 12.375 ms 12.409 ms]
                        change: [-69.174% -69.086% -68.976%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 23 outliers among 100 measurements (23.00%)
  14 (14.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe
```