### PR TITLE
Fix: CI not fail with benchmark job faillures

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -88,7 +88,7 @@ jobs:
           echo "Checking out current preivous branch"
           git checkout -
     - name: Cargo Bench
-      run:  cargo bench --jobs 1 --bench bench -- --output-format bencher | tee output.txt
+      run:  cargo bench --jobs 1 --bench bench -- --output-format bencher | tee output.txt || { echo "Benchmark failed"; exit 1; }
     - name: Compare results & store cached results
       uses: benchmark-action/github-action-benchmark@v1.18.0
       with:


### PR DESCRIPTION
![image](https://github.com/bluerobotics/navigator-rs/assets/80598030/304a1fec-20d8-4270-bcfd-ff1220082c4e)
