### PR TITLE
Fix : Leak sensor : Set gpio Input on first time without need sudo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,7 @@ impl Navigator {
         self.leak
             .export()
             .expect("Error: Failed to export leak pin");
+        Delay {}.delay_ms(30_u16);
         self.leak
             .set_direction(Direction::In)
             .expect("Error: Failed to set leak pin as input");


### PR DESCRIPTION
Known issue faced and solved on SPI's CSs and UserLED pins.

Details:
![image](https://github.com/bluerobotics/navigator-rs/assets/80598030/9aeaba8a-8e99-4345-9406-889e1a7f6803)
