### PR TITLE
Add support to raspberry pi 5

### DIFF
--- a/src/led.rs
+++ b/src/led.rs
@@ -1,11 +1,11 @@
 use std::{thread::sleep, time::Duration};
 
-use linux_embedded_hal::{sysfs_gpio::Direction, Pin};
+use linux_embedded_hal::gpio_cdev::{Chip, LineHandle, LineRequestFlags};
 
 use crate::peripherals::{AnyHardware, LedBehaviour, PeripheralClass, PeripheralInfo, Peripherals};
 
 pub struct LedController {
-    pub leds: Vec<Pin>,
+    pub leds: Vec<LineHandle>,
     pub info: PeripheralInfo,
 }
 
@@ -26,7 +26,7 @@ impl AnyHardware for LedController {
 }
 
 pub struct LedControllerBuilder {
-    pub pins: Vec<u64>,
+    pub pins: Vec<u32>,
     pub info: PeripheralInfo,
 }
 
@@ -42,7 +42,7 @@ impl LedControllerBuilder {
     }
 
     /// Adds a GPIO pin to control an LED.
-    pub fn add_led_pin(mut self, pin_number: u64) -> Self {
+    pub fn add_led_pin(mut self, pin_number: u32) -> Self {
         self.pins.push(pin_number);
         self
     }
@@ -65,12 +65,18 @@ impl LedControllerBuilder {
             self = self.configure_navigator();
         }
 
+        let mut chip = Chip::new("/dev/gpiochip4").unwrap();
         for &pin_number in &self.pins {
-            let pin = Pin::new(pin_number);
-            pin.export().expect("Failed to export LED pin");
+            let pin = chip
+                .get_line(pin_number)
+                .unwrap()
+                .request(
+                    LineRequestFlags::OUTPUT,
+                    1,
+                    &format!("user-led-{pin_number}"),
+                )
+                .expect("Failed to request LED pin");
             sleep(Duration::from_millis(30));
-            pin.set_direction(Direction::Out)
-                .expect("Failed to set direction");
             pin.set_value(1).expect("Failed to set initial LED value");
             leds.push(pin);
         }

--- a/src/pca9685.rs
+++ b/src/pca9685.rs
@@ -1,13 +1,16 @@
 use std::{error::Error, thread::sleep, time::Duration};
 
-use linux_embedded_hal::{sysfs_gpio::Direction, I2cdev, Pin};
+use linux_embedded_hal::{
+    gpio_cdev::{Chip, LineHandle, LineRequestFlags},
+    I2cdev,
+};
 use pwm_pca9685::{Address as PwmAddress, Channel, Pca9685};
 
 use crate::peripherals::{AnyHardware, PeripheralClass, PeripheralInfo, Peripherals, PwmBehaviour};
 
 pub struct Pca9685Device {
     pwm: Pca9685<I2cdev>,
-    oe_pin: Pin,
+    oe_pin: LineHandle,
     info: PeripheralInfo,
 }
 
@@ -30,7 +33,7 @@ impl AnyHardware for Pca9685Device {
 pub struct Pca9685DeviceBuilder {
     i2c_bus: String,
     address: PwmAddress,
-    oe_pin_number: u64,
+    oe_pin_number: u32,
     info: PeripheralInfo,
 }
 
@@ -72,7 +75,7 @@ impl Pca9685DeviceBuilder {
     /// # Arguments
     ///
     /// * `pin_number` - The GPIO pin number for OE.
-    pub fn with_oe_pin(mut self, pin_number: u64) -> Self {
+    pub fn with_oe_pin(mut self, pin_number: u32) -> Self {
         self.oe_pin_number = pin_number;
         self
     }
@@ -89,10 +92,14 @@ impl Pca9685DeviceBuilder {
         let mut pwm = Pca9685::new(device, self.address).expect("Failed to open PWM controller");
 
         let oe_pin = {
-            let pin = Pin::new(self.oe_pin_number);
-            pin.export()?;
+            let mut chip = Chip::new("/dev/gpiochip4")?;
+            let pin = chip
+                .get_line(self.oe_pin_number)
+                .unwrap()
+                .request(LineRequestFlags::OUTPUT, 1, &format!("oe-pin-pca9685"))
+                .expect("Failed to request OE pin");
             sleep(Duration::from_millis(30));
-            pin.set_direction(Direction::High)?;
+            pin.set_value(1)?;
             pin
         };
 
@@ -110,12 +117,9 @@ impl Pca9685DeviceBuilder {
 
 impl PwmBehaviour for Pca9685Device {
     fn enable_output(&mut self, enable: bool) -> Result<(), Box<dyn Error>> {
-        let value = if enable {
-            Direction::Low
-        } else {
-            Direction::High
-        }; // Active low OE pin
-        self.oe_pin.set_direction(value).unwrap();
+        // Active low OE pin
+        let value = if enable { 0 } else { 1 };
+        self.oe_pin.set_value(value).unwrap();
         Ok(())
     }
 


### PR DESCRIPTION
There are a couple of problems:
    - icm20689 does not support the new gpio implementatino
    - bmp390 is not compatible with bmp280 e the only implementation is async 